### PR TITLE
Update GoToWebinar's Base URL

### DIFF
--- a/lib/go_to_webinar.rb
+++ b/lib/go_to_webinar.rb
@@ -9,7 +9,7 @@ require "go_to_webinar/sessions"
 
 module GoToWebinar
   class Client
-    
+
     include HTTParty
     format :json
 
@@ -17,29 +17,29 @@ module GoToWebinar
     include GoToWebinar::Registrants
     include GoToWebinar::Attendees
     include GoToWebinar::Sessions
-    
+
     attr_accessor :access_token
     attr_accessor :organizer_key
-    
+
     def initialize(access_token, organizer_key, extra_params = {})
-      
-      # the access token from oauth 
+
+      # the access token from oauth
       @access_token = access_token
       @organizer_key = organizer_key
-      
+
       @default_params = {
-        :base_uri => "https://api.citrixonline.com/G2W/rest/organizers/#{@organizer_key}/",
+        :base_uri => "https://api.getgo.com/G2W/rest/organizers/#{@organizer_key}/",
         :headers => {
           "Content-type" => "application/json",
           "Accept" => "application/vnd.citrix.g2wapi-v1.1+json",
-          "Authorization" => "OAuth oauth_token=#{@access_token}" 
+          "Authorization" => "OAuth oauth_token=#{@access_token}"
         }
       }
-      
+
       @default_params = @default_params.merge(extra_params).freeze
       self.class.default_options = self.class.default_options.merge(@default_params).freeze
     end
-    
+
   end
 
 end

--- a/lib/go_to_webinar/version.rb
+++ b/lib/go_to_webinar/version.rb
@@ -1,3 +1,3 @@
 module GoToWebinar
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/test_attendees.rb
+++ b/test/test_attendees.rb
@@ -9,7 +9,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
 
     should "generate valid get attendee" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321",:body => '{"registrantKey": "54321"}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321",:body => '{"registrantKey": "54321"}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
@@ -18,7 +18,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid attendee poll answers" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_poll_answers("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -26,7 +26,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendee questions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_questions("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -34,7 +34,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendee survey answers" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_survey_answers("12345","12345", "54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -42,7 +42,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendees for all webinar sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/attendees",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/attendees",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendees_for_all_webinar_sessions("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_registrants.rb
+++ b/test/test_registrants.rb
@@ -9,25 +9,25 @@ class RegistrantsTest < Test::Unit::TestCase
     end
 
     should "generate valid create registrant" do
-      FakeWeb.register_uri(:post, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["201", "Created"])
+      FakeWeb.register_uri(:post, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["201", "Created"])
       @r = @c.create_registrant("12345",{"email" => "nathanwfish@something.com"})
       assert FakeWeb.last_request.body.is_a?(String)
       assert_equal('{"email":"nathanwfish@something.com"}', FakeWeb.last_request.body)
       assert @r.parsed_response.is_a?(Hash)
-      assert_equal('12345', @r.parsed_response["registrantKey"])      
+      assert_equal('12345', @r.parsed_response["registrantKey"])
     end
-    
+
     should "generate valid get registrant" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants/54321", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants/54321", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrant("12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
       assert_not_nil @r.parsed_response["registrantKey"]
- 
+
     end
-    
+
     should "generate valid get registrants" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '[{"registrantKey":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '[{"registrantKey":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrants("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -35,7 +35,7 @@ class RegistrantsTest < Test::Unit::TestCase
     end
 
     should "generate valid get registrant fields" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants/fields", :body => '[{"field":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants/fields", :body => '[{"field":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrant_fields("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_sessions.rb
+++ b/test/test_sessions.rb
@@ -9,7 +9,7 @@ class SessionsTest < Test::Unit::TestCase
     end
 
     should "generate valid get organizer sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_organizer_sessions()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -17,7 +17,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -25,7 +25,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session attendees" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/attendees",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/attendees",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_attendees("54321", "12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -33,7 +33,7 @@ class SessionsTest < Test::Unit::TestCase
     end
 
     should "generate valid get session performance" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/performance",:body => '{"attendance":{"registrantCount":1234}}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/performance",:body => '{"attendance":{"registrantCount":1234}}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_performance("54321", "12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
@@ -42,7 +42,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session polls" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_polls("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -50,7 +50,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session questions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_questions("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -59,7 +59,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session surveys" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_surveys("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -67,7 +67,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinar sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar_sessions("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_webinars.rb
+++ b/test/test_webinars.rb
@@ -9,7 +9,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
 
     should "generate valid get historical webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/historicalWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/historicalWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_historical_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -17,7 +17,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid upcoming webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/upcomingWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/upcomingWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_upcoming_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -26,7 +26,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinar" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -34,7 +34,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
 
     should "generate valid get webinar meeting times" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/meetingTimes",:body => '[{"startTime":"2011-04-26T18:00:00Z"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/meetingTimes",:body => '[{"startTime":"2011-04-26T18:00:00Z"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar_meeting_times("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -42,7 +42,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)


### PR DESCRIPTION
https://redmine.wishpond.com/issues/104227025

Problem:
Effective Dec 4, 2017 GoToWebinar has changed it base url for all
API calls from https://api.citrixonline.com to
https://api.getgo.com

Solution:
Update the base URL everywhere, update specs

More info: https://goto-developer.logmeininc.com/content/important-changes-goto-developer-center-new-domains-apis
  